### PR TITLE
[SELS-85] [FE] Add timer in the button adding category and word

### DIFF
--- a/frontend/e-learning-fe/src/components/admin/addCategory.js
+++ b/frontend/e-learning-fe/src/components/admin/addCategory.js
@@ -16,6 +16,7 @@ function AdminAddCategory() {
   };
 
   const handleAddCategory = async () => {
+    setIsDisableAdd(true);
     await API.category
       .addCategory({
         category_name: categoryName,
@@ -33,6 +34,9 @@ function AdminAddCategory() {
           progress: undefined,
         });
       });
+    setTimeout(() => {
+      setIsDisableAdd(false);
+    }, 2000);
   };
 
   return (

--- a/frontend/e-learning-fe/src/components/admin/addWordAndChoices.js
+++ b/frontend/e-learning-fe/src/components/admin/addWordAndChoices.js
@@ -31,6 +31,7 @@ function AdminAddWordAndChoices() {
   };
 
   const handleAddWordChoices = async () => {
+    setIsDisableAdd(true);
     await API.word
       .addWordChoices({
         word,
@@ -65,6 +66,9 @@ function AdminAddWordAndChoices() {
           });
         }
       });
+    setTimeout(() => {
+      setIsDisableAdd(false);
+    }, 2000);
   };
 
   return (


### PR DESCRIPTION
# Related Links
Asana: https://app.asana.com/0/1203098252776160/1203308755279584/f

# What do you change at this PR?
frontend
Add a SetTimerout in adding a category and word so that the user will not save multiple inputs with the same data

# Target pages
FE
/admin-add-category
/admin-add-word-choices

# Test View Points
In adding a category after filling out the form and then clicking "add", the button should be disabled for 2 seconds
In adding a word after filling out the form and then clicking "add", the button should be disabled for 2 seconds

# TODO / Things to do after merging:
NA

# Commands to run
Frontend

```
cd frontend
cd e-learning-fe
npm start
```
Backend

```
cd backend
.\venv\Scripts\Activate
python manage.py runserver
```

# ScreenShots
![image](https://user-images.githubusercontent.com/112840596/200276869-7702fc49-2787-4d6e-aef3-84c910e163ae.png)

![image](https://user-images.githubusercontent.com/112840596/200276925-5ad29337-6208-4157-bdb7-a0335b6d1fb0.png)
