### PR TITLE
[SELS-107] [FE] Manipulate the loading state if deleting category and word

### DIFF
--- a/frontend/e-learning-fe/src/components/admin/dashboard.js
+++ b/frontend/e-learning-fe/src/components/admin/dashboard.js
@@ -23,6 +23,7 @@ function AdminDashboard() {
   };
 
   const handleDeleteCategory = async (id) => {
+    setIsLoading(true);
     await API.category
       .deleteCategory({
         token,

--- a/frontend/e-learning-fe/src/components/admin/wordsPerCategory.js
+++ b/frontend/e-learning-fe/src/components/admin/wordsPerCategory.js
@@ -27,6 +27,7 @@ function AdminWordsPerCategory() {
       });
   };
   const handleDeleteWord = async (id) => {
+    setIsLoading(true);
     await API.word
       .deleteWord({
         token,


### PR DESCRIPTION
# Related Links
Asana: https://app.asana.com/0/1203098252776160/1203333552894169/f

# What do you change at this PR?
Frontend
- Set the loading to true if fetching data is not done after clicking the delete button in category and word

# Target pages
/admin-dashboard
/admin-words-per-category

# Test View Points
If you click "delete category", the loading component will display if fetching the data is not yet done
If you click "delete word", the loading component will display if fetching the data is not yet done

# TODO / Things to do after merging:
NA

# Commands to run
Frontend

```
cd frontend
cd e-learning-fe
npm start
```
Backend

```
cd backend
.\venv\Scripts\Activate
python manage.py runserver
```
# ScreenShots
NA